### PR TITLE
Expose Service Credentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.5.0
 	github.com/sclevine/spec v1.2.0
 	golang.org/x/net v0.0.0-20190328230028-74de082e2cca // indirect
-	golang.org/x/sys v0.0.0-20190329044733-9eb1bfa1ce65 // indirect
+	golang.org/x/sys v0.0.0-20190402142545-baf5eb976a8c // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ golang.org/x/net v0.0.0-20190328230028-74de082e2cca/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190329044733-9eb1bfa1ce65 h1:hOY+O8MxdkPV10pNf7/XEHaySCiPKxixMKUshfHsGn0=
-golang.org/x/sys v0.0.0-20190329044733-9eb1bfa1ce65/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190402142545-baf5eb976a8c h1:3xiKTkef8QqBJ8q+4fVUDMRoxnI0H/MVNFswa+aExbo=
+golang.org/x/sys v0.0.0-20190402142545-baf5eb976a8c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/services/credentials.go
+++ b/services/credentials.go
@@ -16,29 +16,7 @@
 
 package services
 
-import (
-	"encoding/json"
-	"sort"
-)
-
-// Credentials is the collection of credential keys.
-//
-// In order to encourage good design, this does not include the values even though they exist.  Buildpacks should
-// only extract values at startup/runtime and not embed them in image.
-type Credentials []string
-
-// UnmarshalJSON makes Credentials satisfy the json.Unmarshaler interface.
-func (c *Credentials) UnmarshalJSON(text []byte) error {
-	var in map[string]interface{}
-
-	if err := json.Unmarshal(text, &in); err != nil {
-		return err
-	}
-
-	for key, _ := range in {
-		*c = append(*c, key)
-	}
-
-	sort.Strings(*c)
-	return nil
-}
+// Credentials is the collection of credentials available exposed by a service.
+// Great care should be used when handling credentials, as they expose sensitive information.
+// Buildpacks should only extract values at startup/runtime and not embed them in the image.
+type Credentials map[string]interface{}

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -84,14 +84,14 @@ func TestServices(t *testing.T) {
 			g.Expect(s).To(Equal(services.Services{
 				{
 					BindingName:  "elephantsql-binding-c6c60",
-					Credentials:  services.Credentials{"uri"},
+					Credentials:  services.Credentials{"uri": "postgres://exampleuser:examplepass@babar.elephantsql.com:5432/exampleuser"},
 					InstanceName: "elephantsql-c6c60",
 					Label:        "elephantsql",
 					Plan:         "turtle",
 					Tags:         []string{"postgres", "postgresql", "relational"},
 				},
 				{
-					Credentials:  services.Credentials{"hostname", "password", "username"},
+					Credentials:  services.Credentials{"hostname": "smtp.sendgrid.net", "password": "HCHMOYluTv", "username": "QvsXMbJ3rK"},
 					InstanceName: "mysendgrid",
 					Label:        "sendgrid",
 					Plan:         "free",


### PR DESCRIPTION
Previously service credentials were only exposed as an array of service names. This
commit adds the payload for each service as well.

Signed-off-by: Paul Harris <pharris@pivotal.io>