### PR TITLE
Support direct process executions

### DIFF
--- a/layers/layers.go
+++ b/layers/layers.go
@@ -42,7 +42,7 @@ func (l Layers) Layer(name string) Layer {
 func (l Layers) WriteApplicationMetadata(metadata Metadata) error {
 	f := filepath.Join(l.Root, "launch.toml")
 
-	l.logger.Debug("Writing application metadata: %s <= %s", f, metadata)
+	l.logger.Debug("Writing application metadata: %s <= %v", f, metadata)
 	return internal.WriteTomlFile(f, 0644, metadata)
 }
 

--- a/layers/layers_test.go
+++ b/layers/layers_test.go
@@ -53,7 +53,7 @@ func TestLayers(t *testing.T) {
 			g.Expect(layers.Layers{Root: root}.WriteApplicationMetadata(layers.Metadata{
 				Processes: layers.Processes{
 					layers.Process{Type: "web", Command: "command-1"},
-					layers.Process{Type: "task", Command: "command-2"},
+					layers.Process{Type: "task", Command: "command-2", Direct: true},
 				},
 				Slices: layers.Slices{
 					layers.Slice{Paths: []string{"/slice-1/path-1", "/slice-1/path-2"}},
@@ -64,10 +64,12 @@ func TestLayers(t *testing.T) {
 			g.Expect(filepath.Join(root, "launch.toml")).To(internal.HaveContent(`[[processes]]
   type = "web"
   command = "command-1"
+  direct = false
 
 [[processes]]
   type = "task"
   command = "command-2"
+  direct = true
 
 [[slices]]
   paths = ["/slice-1/path-1", "/slice-1/path-2"]

--- a/layers/process.go
+++ b/layers/process.go
@@ -26,4 +26,7 @@ type Process struct {
 
 	// Command is the command of the process.
 	Command string `toml:"command"`
+
+	// Command is exec'd directly by the os (no profile.d scripts run)
+	Direct bool `toml:"direct"`
 }


### PR DESCRIPTION
Adds `direct` to process struct to allow execing by os

Supported in the lifecycle via https://github.com/buildpack/lifecycle/pull/148
Co-authored-by: Zander Mackie <amackie@pivotal.io>