### PR TITLE
Fix order-induced flakiness in services_test

### DIFF
--- a/services/services_test.go
+++ b/services/services_test.go
@@ -81,7 +81,7 @@ func TestServices(t *testing.T) {
 			s, err := services.DefaultServices(platform.Platform{}, logger.Logger{})
 			g.Expect(err).To(gomega.Succeed())
 
-			g.Expect(s).To(gomega.Equal(services.Services{
+			g.Expect(s).To(gomega.ConsistOf(services.Services{
 				{
 					BindingName:  "elephantsql-binding-c6c60",
 					Credentials:  services.Credentials{"uri": "postgres://exampleuser:examplepass@babar.elephantsql.com:5432/exampleuser"},


### PR DESCRIPTION
Was seeing test failure due to out of order lists. It seems the order doesn't matter (the input is a map), so I've adjusted the gomega comparison, but I'm not sure if this is the appropriate fix.